### PR TITLE
CI - Update "benchmark" v1.8.4 -> v1.8.5

### DIFF
--- a/cpm.dependencies
+++ b/cpm.dependencies
@@ -252,7 +252,7 @@
     },
     {
       "name": "benchmark",
-      "version": "1.8.4",
+      "version": "1.8.5",
       "github_repository": "google/benchmark",
       "options": [
         "BENCHMARK_ENABLE_TESTING OFF",


### PR DESCRIPTION
Update dependency benchmark from version v1.8.4 to v1.8.5