### PR TITLE
CI - Update "compile-time-regular-expressions" v3.8.1 -> v3.9.0

### DIFF
--- a/cpm.dependencies
+++ b/cpm.dependencies
@@ -140,7 +140,7 @@
     },
     {
       "name": "compile-time-regular-expressions",
-      "version": "3.8.1",
+      "version": "3.9.0",
       "github_repository": "hanickadot/compile-time-regular-expressions",
       "git_tag_ignore": [
         "cppcon2018",


### PR DESCRIPTION
Update dependency compile-time-regular-expressions from version v3.8.1 to v3.9.0