### PR TITLE
CI - Update "Catch2" v3.6.0 -> v3.7.0

### DIFF
--- a/cpm.dependencies
+++ b/cpm.dependencies
@@ -30,7 +30,7 @@
     },
     {
       "name": "Catch2",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "github_repository": "catchorg/Catch2"
     },
     {


### PR DESCRIPTION
Update dependency Catch2 from version v3.6.0 to v3.7.0