### PR TITLE
CI - Update "pybind11" v2.13.1 -> v2.13.4

### DIFF
--- a/cpm.dependencies
+++ b/cpm.dependencies
@@ -88,7 +88,7 @@
     },
     {
       "name": "pybind11",
-      "version": "2.13.1",
+      "version": "2.13.4",
       "github_repository": "pybind/pybind11"
     },
     {


### PR DESCRIPTION
Update dependency pybind11 from version v2.13.1 to v2.13.4