### PR TITLE
CI - Update "benchmark" v1.8.5 -> v1.9.0

### DIFF
--- a/cpm.dependencies
+++ b/cpm.dependencies
@@ -252,7 +252,7 @@
     },
     {
       "name": "benchmark",
-      "version": "1.8.5",
+      "version": "1.9.0",
       "github_repository": "google/benchmark",
       "options": [
         "BENCHMARK_ENABLE_TESTING OFF",


### PR DESCRIPTION
Update dependency benchmark from version v1.8.5 to v1.9.0