### PR TITLE
CI - Update Libraries 28ec94dd789ae968fa647a98f9a22cdee3d144c0fe9fb9aad9520243f6ea85c9

### DIFF
--- a/cpm.dependencies
+++ b/cpm.dependencies
@@ -30,7 +30,7 @@
     },
     {
       "name": "Catch2",
-      "version": "3.6.0",
+      "version": "3.7.0",
       "github_repository": "catchorg/Catch2"
     },
     {
@@ -46,7 +46,7 @@
     },
     {
       "name": "7-Zip",
-      "version": "24.07",
+      "version": "24.08",
       "github_repository": "rikyoz/7-Zip",
       "cmake_commands": [
         "file(GLOB SOURCE_FILES ${CPM_CURRENT_SOURCE_DIR}/C/*.c)",
@@ -64,11 +64,12 @@
     {
       "name": "absl",
       "github_repository": "abseil/abseil-cpp",
-      "git_tag": "20240116.2",
+      "git_tag": "20240722.0",
       "options": [
         "ABSL_ENABLE_INSTALL ON",
         "ABSL_PROPAGATE_CXX_STD ON"
-      ]
+      ],
+      "version": "20240722.0"
     },
     {
       "name": "bit7z",
@@ -88,7 +89,7 @@
     },
     {
       "name": "pybind11",
-      "version": "2.13.1",
+      "version": "2.13.4",
       "github_repository": "pybind/pybind11"
     },
     {
@@ -99,7 +100,7 @@
     },
     {
       "name": "rapidyaml",
-      "version": "0.7.0",
+      "version": "0.7.1",
       "github_repository": "biojppm/rapidyaml"
     },
     {
@@ -186,12 +187,12 @@
     },
     {
       "name": "libsais",
-      "version": "2.8.4",
+      "version": "2.8.5",
       "github_repository": "IlyaGrebnov/libsais"
     },
     {
       "name": "fmindex-collection",
-      "version": "0.3.3",
+      "version": "0.4.0",
       "github_repository": "SGSSGene/fmindex-collection"
     },
     {
@@ -252,7 +253,7 @@
     },
     {
       "name": "benchmark",
-      "version": "1.8.5",
+      "version": "1.9.0",
       "github_repository": "google/benchmark",
       "options": [
         "BENCHMARK_ENABLE_TESTING OFF",
@@ -262,7 +263,7 @@
     },
     {
       "name": "googletest",
-      "version": "1.15.0",
+      "version": "1.15.2",
       "github_repository": "google/googletest",
       "options": [
         "BUILD_GMOCK ON"


### PR DESCRIPTION

- Catch2 from version v3.6.0 to v3.7.0
- 7-Zip from version v24.07 to v24.08
- absl from version 20240116.2 to 20240722.0
- pybind11 from version v2.13.1 to v2.13.4
- rapidyaml from version v0.7.0 to v0.7.1
- libsais from version v2.8.4 to v2.8.5
- fmindex-collection from version v0.3.3 to v0.4.0
- benchmark from version v1.8.5 to v1.9.0
- googletest from version v1.15.0 to v1.15.2