### PR TITLE
CI - Update Libraries 2fe445833ad91718e171b79da456c2f633a30923cc14c2b527645afb86422b8d

### DIFF
--- a/cpm.dependencies
+++ b/cpm.dependencies
@@ -89,7 +89,7 @@
     },
     {
       "name": "pybind11",
-      "version": "2.13.4",
+      "version": "2.13.5",
       "github_repository": "pybind/pybind11"
     },
     {


### PR DESCRIPTION
Libraries require updating:
- **pybind11**: v2.13.4 → v2.13.5