### PR TITLE
CI - Update Libraries b12a6791a8782a977f67b709035c4204b27e7e08f6f03f40af954fa2952692dd

### DIFF
--- a/cpm.dependencies
+++ b/cpm.dependencies
@@ -8,7 +8,7 @@
     },
     {
       "name": "PackageProject.cmake",
-      "version": "1.11.2",
+      "version": "1.12.0",
       "github_repository": "TheLartians/PackageProject.cmake"
     },
     {
@@ -89,7 +89,7 @@
     },
     {
       "name": "pybind11",
-      "version": "2.13.5",
+      "version": "2.13.6",
       "github_repository": "pybind/pybind11"
     },
     {


### PR DESCRIPTION
Libraries require updating:
- **PackageProject.cmake**: v1.11.2 → v1.12.0
- **pybind11**: v2.13.5 → v2.13.6
fixes #60
